### PR TITLE
feat: add aarch64 support to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,9 @@
 
       systems = [
         "x86_64-linux"
+        "aarch64-linux"
         "x86_64-darwin"
+        "aarch64-darwin"
       ];
 
       debug = false;


### PR DESCRIPTION
Tested it on `aarch64-darwin` and it works. 