### PR TITLE
fix: use default base derivation path instead of root derivation path

### DIFF
--- a/internal/wallet/wallet.go
+++ b/internal/wallet/wallet.go
@@ -21,8 +21,8 @@ func NewWallet(mnemonic, alias string, customDerivationPath ...string) (*Wallet,
 		return nil, fmt.Errorf("failed to create wallet from mnemonic: %w", err)
 	}
 
-	// Use the default root derivation path unless a custom path is provided
-	derivationPath := hdwallet.DefaultRootDerivationPath.String()
+	// Use the default base derivation path unless a custom path is provided
+	derivationPath := hdwallet.DefaultBaseDerivationPath.String()
 	if len(customDerivationPath) > 0 && customDerivationPath[0] != "" {
 		derivationPath = customDerivationPath[0]
 	}


### PR DESCRIPTION
We were seeing inconsistent behaviour creating wallets and verifying their behaviour against https://iancoleman.io/bip39/, as well as when using the generated mnemonic in other libraries for the iOS and so on.

This change makes things behave consistently.

@aldoborrero can you remember why it was done the other way?
